### PR TITLE
Remove non random-access iterator overloads

### DIFF
--- a/include/bitlib/bit-algorithms/count.hpp
+++ b/include/bitlib/bit-algorithms/count.hpp
@@ -22,16 +22,15 @@
 namespace bit {
 // ========================================================================== //
 
-template <class RandomAccessIt>
+template<class RandomAccessIt>
 constexpr typename bit_iterator<RandomAccessIt>::difference_type
-count_dispatch(
-        bit_iterator<RandomAccessIt> first, 
-        bit_iterator<RandomAccessIt> last,
-        std::random_access_iterator_tag
+count(
+    bit_iterator <RandomAccessIt> first,
+    bit_iterator <RandomAccessIt> last,
+    bit_value value
 ) {
     // Assertions
     _assert_range_viability(first, last);
-    //assert(first.position() == 0);
 
     // Types and constants
     using word_type = typename bit_iterator<RandomAccessIt>::word_type;
@@ -40,86 +39,30 @@ count_dispatch(
 
     // Initialization
     difference_type result = 0;
-    RandomAccessIt it = first.base();
-
-    if (first.position() != 0) {
-        word_type first_value = *first.base() >> first.position();
-        result = _popcnt(first_value);
-        ++it;
-    }
-    for (; it != last.base() && !is_aligned(&(*it), 64); ++it) {
-        result += _popcnt(*it);
-    }
-    result += std::transform_reduce(
-            it, 
-            last.base(), 
-            0, 
-            std::plus{}, 
-            [](word_type word) {return _popcnt(word); }
-    );
-    if (last.position() != 0) {
-        word_type last_value = *last.base() << (digits - last.position());
-        result += _popcnt(last_value);
-    }
-    return result;
-}
-
-template <class InputIt>
-constexpr typename bit_iterator<InputIt>::difference_type
-count_dispatch(
-        bit_iterator<InputIt> first, 
-        bit_iterator<InputIt> last,
-        std::input_iterator_tag
-) {
-    // Assertions
-    _assert_range_viability(first, last);
-    //assert(first.position() == 0);
-
-    // Types and constants
-    using word_type = typename bit_iterator<InputIt>::word_type;
-    using difference_type = typename bit_iterator<InputIt>::difference_type;
-    constexpr difference_type digits = binary_digits<word_type>::value;
-
-    // Initialization
-    difference_type result = 0;
-    InputIt it = first.base();
-
-    if (first.position() != 0) {
-        word_type first_value = *first.base() >> first.position();
-        result = _popcnt(first_value);
-        ++it;
-    }
-    for (; it != last.base(); ++it) {
-        result += _popcnt(*it);
-    }
-    if (last.position() != 0) {
-        word_type last_value = *last.base() << (digits - last.position());
-        result += _popcnt(last_value);
-    }
-    return result;
-}
-
-// Status: complete
-template<class InputIt>
-constexpr typename bit_iterator<InputIt>::difference_type
-count(
-    bit_iterator <InputIt> first,
-    bit_iterator <InputIt> last,
-    bit_value value
-) {
-    // Assertions
-    _assert_range_viability(first, last);
-
-    // Types and constants
-    using word_type = typename bit_iterator<InputIt>::word_type;
-    using difference_type = typename bit_iterator<InputIt>::difference_type;
-
-    // Initialization
-    difference_type result = 0;
 
     // Computation when bits belong to several underlying words
     if (first.base() != last.base()) {
-        result = count_dispatch(first, last, typename std::iterator_traits<InputIt>::iterator_category());
+        RandomAccessIt it = first.base();
+
+        if (first.position() != 0) {
+            word_type first_value = *first.base() >> first.position();
+            result = _popcnt(first_value);
+            ++it;
+        }
+        for (; it != last.base() && !is_aligned(&(*it), 64); ++it) {
+            result += _popcnt(*it);
+        }
+        result += std::transform_reduce(
+                it, 
+                last.base(), 
+                0, 
+                std::plus{}, 
+                [](word_type word) {return _popcnt(word); }
+        );
+        if (last.position() != 0) {
+            word_type last_value = *last.base() << (digits - last.position());
+            result += _popcnt(last_value);
+        }
     // Computation when bits belong to the same underlying word
     } else {
         result = _popcnt(

--- a/include/bitlib/bit-algorithms/fill.hpp
+++ b/include/bitlib/bit-algorithms/fill.hpp
@@ -27,14 +27,14 @@ namespace bit {
 
 
 // Status: needs revisions
-template <class ForwardIt>
-void fill(bit_iterator<ForwardIt> first, bit_iterator<ForwardIt> last, 
+template <class RandomAccessIt>
+void fill(bit_iterator<RandomAccessIt> first, bit_iterator<RandomAccessIt> last, 
     bit::bit_value bv) {
     // Assertions
     _assert_range_viability(first, last);
 
     // Types and constants
-    using word_type = typename bit_iterator<ForwardIt>::word_type;
+    using word_type = typename bit_iterator<RandomAccessIt>::word_type;
     constexpr word_type digits = binary_digits<word_type>::value;
 
     // Initializations

--- a/include/bitlib/bit-algorithms/reverse.hpp
+++ b/include/bitlib/bit-algorithms/reverse.hpp
@@ -25,18 +25,18 @@ namespace bit {
 
 // --------------------------- Reverse Algorithms --------------------------- //
 // Status: complete
-template <class BidirIt>
+template <class RandomAccessIt>
 constexpr void reverse(
-    bit_iterator<BidirIt> first,
-    bit_iterator<BidirIt> last
+    bit_iterator<RandomAccessIt> first,
+    bit_iterator<RandomAccessIt> last
 )
 {
     // Assertions
     _assert_range_viability(first, last);
 
     // Types and constants
-    using word_type = typename bit_iterator<BidirIt>::word_type;
-    using size_type = typename bit_iterator<BidirIt>::size_type;
+    using word_type = typename bit_iterator<RandomAccessIt>::word_type;
+    using size_type = typename bit_iterator<RandomAccessIt>::size_type;
     constexpr size_type digits = binary_digits<word_type>::value;
 
     // Initialization
@@ -50,9 +50,7 @@ constexpr void reverse(
     // Reverse when bit iterators are aligned
     if (is_first_aligned && is_last_aligned) {
         std::reverse(first.base(), last.base());
-        for (; it !=  last.base(); ++it) {
-            *it = _bitswap(*it);
-        }
+        std::transform(it, last.base(), it, [](word_type w) { return _bitswap(w); });
         // Reverse when bit iterators do not belong to the same underlying word
     } else if (first.base() != last.base()) {
         // Save first and last element
@@ -61,9 +59,12 @@ constexpr void reverse(
         // Reverse the underlying sequence
         std::reverse(first.base(), std::next(last.base(), !is_last_aligned));
         // Bitswap every element of the underlying sequence
-        for (it = first.base(); it != std::next(last.base(), !is_last_aligned); ++it) {
-            *it = _bitswap(*it);
-        }
+        std::transform(
+                first.base(),
+                std::next(last.base(), !is_last_aligned),
+                first.base(),
+                [](word_type w) { return _bitswap(w); }
+        );
         // Shift the underlying sequence to the left
         if (first.position() < gap) {
             gap = gap - first.position();

--- a/include/bitlib/bit-algorithms/rotate.hpp
+++ b/include/bitlib/bit-algorithms/rotate.hpp
@@ -27,7 +27,7 @@ namespace bit {
 //
 // Note: distance(first, n_first) <= 3*digits
 template <class ForwardIt, int BufferSize>
-bit_iterator<ForwardIt> rotate_via_copy_begin(
+bit_iterator<ForwardIt> _rotate_via_copy_begin(
    bit_iterator<ForwardIt> first, 
    bit_iterator<ForwardIt> n_first,
    bit_iterator<ForwardIt> last
@@ -65,7 +65,7 @@ bit_iterator<ForwardIt> rotate_via_copy_begin(
 //
 // Note: distance(n_first, last) <= 3*digits
 template <class ForwardIt, int BufferSize>
-bit_iterator<ForwardIt> rotate_via_copy_end(
+bit_iterator<ForwardIt> _rotate_via_copy_end(
    bit_iterator<ForwardIt> first, 
    bit_iterator<ForwardIt> n_first,
    bit_iterator<ForwardIt> last
@@ -101,7 +101,7 @@ bit_iterator<ForwardIt> rotate_via_copy_end(
 // Rotates a range using random-access iterators. Algorithm logic from the GCC
 // implementation
 template <class RandomAccessIt>
-bit_iterator<RandomAccessIt> rotate_via_raw(
+bit_iterator<RandomAccessIt> _rotate_via_raw(
    bit_iterator<RandomAccessIt> first, 
    bit_iterator<RandomAccessIt> n_first,
    bit_iterator<RandomAccessIt> last,
@@ -129,7 +129,7 @@ bit_iterator<RandomAccessIt> rotate_via_raw(
         if (k < n - k) {
             if (k <= digits) {
                 // BENCHMARK NOTE: may be better to do k <= 3*digits and use
-                // the rotate_via_copy method.
+                // the _rotate_via_copy method.
                 word_type temp_word = get_word<word_type>(p, k);
                 bit_iterator<RandomAccessIt> temp_it = shift_left(p, p + n, k);
                 write_word<word_type>(temp_word, temp_it, k);
@@ -250,7 +250,7 @@ bit_iterator<ForwardIt> rotate(
         write_word(temp, first, static_cast<word_type>(p));
         return new_last;
     }
-    return rotate_via_raw(
+    return _rotate_via_raw(
             first, 
             n_first, 
             last,

--- a/include/bitlib/bit-algorithms/shift.hpp
+++ b/include/bitlib/bit-algorithms/shift.hpp
@@ -35,116 +35,18 @@ namespace bit {
 
 
 // --------------------------- Shift Algorithms ----------------------------- //
-template <class ForwardIt>
-bit_iterator<ForwardIt> shift_right_dispatch(
-        bit_iterator<ForwardIt> first,
-        bit_iterator<ForwardIt> last,
-        typename bit_iterator<ForwardIt>::difference_type n,
-        std::forward_iterator_tag
-)
-{
-    // Assertions
-     _assert_range_viability(first, last); 
 
-    // Types and constants
-    using word_type = typename bit_iterator<ForwardIt>::word_type;
-    using size_type = typename bit_iterator<ForwardIt>::size_type;
-    constexpr size_type digits = binary_digits<word_type>::value;
-
-    // Initialization
-    size_type word_shifts = n / digits; 
-    size_type remaining_bitshifts = n - digits*(word_shifts);
-    const bool is_first_aligned = first.position() == 0;
-    const bool is_last_aligned = last.position() == 0;
-    auto d = distance(first, last);
-
-    // Out of range cases
-    if (n <= 0) return first;
-    else if (n >= d) return last;
-
-    // Single word case
-    if (first.base() == last.base()) {
-        *first.base() = _bitblend<word_type>(
-                *first.base(),
-                (
-                    *first.base() & (
-                        static_cast<word_type>(-1) << first.position()
-                    )
-                ) << n,
-                first.position(),
-                last.position() - first.position()
-        );
-        return bit_iterator<ForwardIt>(
-                first.base(), 
-                first.position() +  n
-        );
-    }
-
-    // Multiple word case
-    word_type first_value = *first.base();
-    word_type last_value = !is_last_aligned ? *last.base() : 0;
-    word_type mask = is_first_aligned ? 
-        static_cast<word_type>(-1)
-        : 
-        static_cast<word_type>(
-                (static_cast<word_type>(1) << (digits - first.position())) - 1
-        ) << first.position();
-    *first.base() = *first.base() & mask;
-    // Shift words to the right
-    ForwardIt it = STD_SHIFT_RIGHT(first.base(), 
-                               std::next(last.base(), 
-                                         !is_last_aligned
-                                         ),
-                               word_shifts
-    );
-    bit_iterator<ForwardIt> d_first(it, first.position());
-    // Shift bit sequence to the msb 
-    if (remaining_bitshifts) {
-        word_type temp_1 = *it;
-        word_type temp_2;
-        *it = *it << remaining_bitshifts;
-        it++;
-        //TODO probably a way to do this with 1 temp or
-        // at least no value swapping
-        for (; it != std::next(last.base(), !is_last_aligned); ++it) {
-            temp_2 = *it;
-            *it = _shld<word_type>(*it, temp_1, remaining_bitshifts);
-            temp_1 = temp_2; 
-        }
-    }
-    // Blend bits of the first element
-    if (!is_first_aligned) {
-        *first.base() = _bitblend<word_type>(
-                first_value,
-                *first.base(),
-                first.position(),
-                digits - first.position()
-        );
-    }
-    // Blend bits of the last element
-    if (!is_last_aligned) {
-        *last.base() = _bitblend<word_type>(
-                *last.base(),
-                last_value,
-                last.position(),
-                digits - last.position()
-        );
-    }
-    advance(d_first, remaining_bitshifts);
-    return d_first;
-}
-
-template <class ForwardIt>
-bit_iterator<ForwardIt> shift_left_dispatch(
-        bit_iterator<ForwardIt> first,
-        bit_iterator<ForwardIt> last,
-        typename bit_iterator<ForwardIt>::difference_type n,
+template <class RandomAccessIt>
+bit_iterator<RandomAccessIt> shift_left_dispatch(
+        bit_iterator<RandomAccessIt> first,
+        bit_iterator<RandomAccessIt> last,
+        typename bit_iterator<RandomAccessIt>::difference_type n,
         std::forward_iterator_tag
 )
 {
     // Types and constants
-    using word_type = typename bit_iterator<ForwardIt>::word_type;
-    using size_type = typename bit_iterator<ForwardIt>::size_type;
+    using word_type = typename bit_iterator<RandomAccessIt>::word_type;
+    using size_type = typename bit_iterator<RandomAccessIt>::size_type;
     constexpr size_type digits = binary_digits<word_type>::value;
 
     // Initialization
@@ -159,7 +61,7 @@ bit_iterator<ForwardIt> shift_left_dispatch(
     word_type last_value = !is_last_aligned ? *last.base() : 0;
 
     // Shift words to the left using std::shift 
-    ForwardIt new_last_base = STD_SHIFT_LEFT(first.base(), 
+    RandomAccessIt new_last_base = STD_SHIFT_LEFT(first.base(), 
                                     last.base(),
                                     word_shifts
     );
@@ -173,7 +75,7 @@ bit_iterator<ForwardIt> shift_left_dispatch(
     }
     // Shift bit sequence to the lsb 
     if (remaining_bitshifts) {
-        ForwardIt it = first.base();
+        RandomAccessIt it = first.base();
         // _shrd all words except the last
         for (; std::next(it, is_last_aligned) != new_last_base; ++it) {
             *it = _shrd<word_type>(*it, *std::next(it), remaining_bitshifts);
@@ -201,7 +103,7 @@ bit_iterator<ForwardIt> shift_left_dispatch(
         );
     }
     //TODO is this more or less inefficient than having a latent iterator?
-    bit_iterator<ForwardIt> d_last = next(first, d-n);
+    bit_iterator<RandomAccessIt> d_last = next(first, d-n);
     return d_last;
 }
 
@@ -272,24 +174,54 @@ bit_iterator<RandomAccessIt> shift_right_dispatch(
     return d_first;
 }
 
+
 template <class RandomAccessIt>
-bit_iterator<RandomAccessIt> shift_left_dispatch(
+bit_iterator<RandomAccessIt> shift_left(
         bit_iterator<RandomAccessIt> first,
         bit_iterator<RandomAccessIt> last,
-        typename bit_iterator<RandomAccessIt>::difference_type n,
-        std::random_access_iterator_tag
+        typename bit_iterator<RandomAccessIt>::difference_type n
 ) {
+    // Assertions
+     _assert_range_viability(first, last); 
+
     // Types and constants
     using word_type = typename bit_iterator<RandomAccessIt>::word_type;
     using size_type = typename bit_iterator<RandomAccessIt>::size_type;
     constexpr size_type digits = binary_digits<word_type>::value;
 
     // Initialization
-    size_type word_shifts = n / digits; 
-    size_type remaining_bitshifts = n - digits*(word_shifts);
+    auto d = distance(first, last);
     const bool is_first_aligned = first.position() == 0;
     const bool is_last_aligned = last.position() == 0;
-    auto d = distance(first, last);
+
+    // Out of range cases
+    if (n <= 0) return last;
+    if (n >= d) return first;
+
+
+    // Single word case
+    if (std::next(first.base(), is_last_aligned) == last.base()) {
+        *first.base() = _bitblend<word_type>(
+                *first.base(),
+                ((
+                    *first.base() & (
+                        static_cast<word_type>(-1) >> (
+                            digits - (is_last_aligned ? digits : last.position())
+                        )
+                    )
+                )) >> n,
+                first.position(),
+                (is_last_aligned ? digits : last.position()) - first.position()
+        );
+        return bit_iterator<RandomAccessIt>(
+                first.base(), 
+                first.position() + d - n
+        );
+    }
+
+    // More initialization
+    size_type word_shifts = n / digits; 
+    size_type remaining_bitshifts = n - digits*(word_shifts);
 
     // Multiple word case
     word_type first_value = *first.base();
@@ -342,69 +274,18 @@ bit_iterator<RandomAccessIt> shift_left_dispatch(
     return d_last;
 }
 
-
-template <class ForwardIt>
-bit_iterator<ForwardIt> shift_left(
-        bit_iterator<ForwardIt> first,
-        bit_iterator<ForwardIt> last,
-        typename bit_iterator<ForwardIt>::difference_type n
-) {
-    // Assertions
-     _assert_range_viability(first, last); 
-
-    // Types and constants
-    using word_type = typename bit_iterator<ForwardIt>::word_type;
-    using size_type = typename bit_iterator<ForwardIt>::size_type;
-    constexpr size_type digits = binary_digits<word_type>::value;
-
-    // Initialization
-    auto d = distance(first, last);
-    const bool is_last_aligned = last.position() == 0;
-
-    // Out of range cases
-    if (n <= 0) return last;
-    if (n >= d) return first;
-
-
-    // Single word case
-    if (std::next(first.base(), is_last_aligned) == last.base()) {
-        *first.base() = _bitblend<word_type>(
-                *first.base(),
-                ((
-                    *first.base() & (
-                        static_cast<word_type>(-1) >> (
-                            digits - (is_last_aligned ? digits : last.position())
-                        )
-                    )
-                )) >> n,
-                first.position(),
-                (is_last_aligned ? digits : last.position()) - first.position()
-        );
-        return bit_iterator<ForwardIt>(
-                first.base(), 
-                first.position() + d - n
-        );
-    }
-    else {
-        return shift_left_dispatch(
-                first, 
-                last,
-                n,
-                typename std::iterator_traits<ForwardIt>::iterator_category()
-        );
-    }
-}
-
-template <class ForwardIt>
-bit_iterator<ForwardIt> shift_right(
-        bit_iterator<ForwardIt> first,
-        bit_iterator<ForwardIt> last,
-        typename bit_iterator<ForwardIt>::difference_type n
+template <class RandomAccessIt>
+bit_iterator<RandomAccessIt> shift_right(
+        bit_iterator<RandomAccessIt> first,
+        bit_iterator<RandomAccessIt> last,
+        typename bit_iterator<RandomAccessIt>::difference_type n
 ) {
     // Types and constants
-    using word_type = typename bit_iterator<ForwardIt>::word_type;
+    using word_type = typename bit_iterator<RandomAccessIt>::word_type;
+    using size_type = typename bit_iterator<RandomAccessIt>::size_type;
 
     // Initialization
+    const bool is_first_aligned = first.position() == 0;
     const bool is_last_aligned = last.position() == 0;
     constexpr auto digits = binary_digits<word_type>::value;
     auto d = distance(first, last);
@@ -425,18 +306,63 @@ bit_iterator<ForwardIt> shift_right(
                 first.position(),
                 (is_last_aligned ? digits : last.position()) - first.position()
         );
-        return bit_iterator<ForwardIt>(
+        return bit_iterator<RandomAccessIt>(
                 first.base(), 
                 first.position() +  n
         );
     }
 
-    return shift_right_dispatch(
-            first, 
-            last,
-            n,
-            typename std::iterator_traits<ForwardIt>::iterator_category()
+    // More initialization
+    size_type word_shifts = n / digits; 
+    size_type remaining_bitshifts = n - digits*(word_shifts);
+
+    // Multiple word case
+    word_type first_value = *first.base();
+    word_type last_value = !is_last_aligned ? *last.base() : 0;
+    word_type mask = is_first_aligned ? 
+        static_cast<word_type>(-1)
+        : 
+        static_cast<word_type>(
+                (static_cast<word_type>(1) << (digits - first.position())) - 1
+        ) << first.position();
+    *first.base() = *first.base() & mask;
+    // Shift words to the right
+    RandomAccessIt new_first_base = STD_SHIFT_RIGHT(
+        first.base(), 
+        std::next(
+            last.base(), 
+            !is_last_aligned),
+        word_shifts
     );
+    bit_iterator<RandomAccessIt> d_first(new_first_base, first.position());
+    // Shift bit sequence to the msb 
+    if (remaining_bitshifts) {
+        auto it = is_last_aligned ? last.base() - 1 : last.base();
+        for(; it != new_first_base; --it) {
+            *it = _shld<word_type>(*it, *(it - 1), remaining_bitshifts);
+        }
+        *it <<= remaining_bitshifts;
+    }
+    // Blend bits of the first element
+    if (!is_first_aligned) {
+        *first.base() = _bitblend<word_type>(
+                first_value,
+                *first.base(),
+                first.position(),
+                digits - first.position()
+        );
+    }
+    // Blend bits of the last element
+    if (!is_last_aligned) {
+        *last.base() = _bitblend<word_type>(
+                *last.base(),
+                last_value,
+                last.position(),
+                digits - last.position()
+        );
+    }
+    advance(d_first, remaining_bitshifts);
+    return d_first;
 }
 // -------------------------------------------------------------------------- //
 

--- a/include/bitlib/bit-algorithms/swap_ranges.hpp
+++ b/include/bitlib/bit-algorithms/swap_ranges.hpp
@@ -21,20 +21,20 @@
 namespace bit {
 // ========================================================================== //
 
-template< class ForwardIt1, class ForwardIt2 >
-constexpr bit_iterator<ForwardIt2> swap_ranges(
-        bit_iterator<ForwardIt1> first1, 
-        bit_iterator<ForwardIt1> last1,
-        bit_iterator<ForwardIt2> first2) 
+template< class RandomAccessIt1, class RandomAccessIt2 >
+constexpr bit_iterator<RandomAccessIt2> swap_ranges(
+        bit_iterator<RandomAccessIt1> first1, 
+        bit_iterator<RandomAccessIt1> last1,
+        bit_iterator<RandomAccessIt2> first2) 
 {
     // Assertions
     _assert_range_viability(first1, last1);
 
     // Types and constants
-    using word_type1 = typename bit_iterator<ForwardIt1>::word_type;
-    using word_type2 = typename bit_iterator<ForwardIt2>::word_type;
-    using size_type1 = typename bit_iterator<ForwardIt1>::size_type;
-    using size_type2 = typename bit_iterator<ForwardIt2>::size_type;
+    using word_type1 = typename bit_iterator<RandomAccessIt1>::word_type;
+    using word_type2 = typename bit_iterator<RandomAccessIt2>::word_type;
+    using size_type1 = typename bit_iterator<RandomAccessIt1>::size_type;
+    using size_type2 = typename bit_iterator<RandomAccessIt2>::size_type;
     constexpr size_type1 digits1 = binary_digits<word_type1>::value;
     constexpr size_type2 digits2 = binary_digits<word_type2>::value;
 
@@ -42,8 +42,8 @@ constexpr bit_iterator<ForwardIt2> swap_ranges(
     //const bool is_first1_aligned = first1.position() == 0;
     const bool is_last1_aligned = last1.position() == 0;
     //const bool is_first2_aligned = first2.position() == 0;
-    ForwardIt1 it1 = first1.base();
-    ForwardIt2 it2 = first2.base();
+    RandomAccessIt1 it1 = first1.base();
+    RandomAccessIt2 it2 = first2.base();
     
     if (first1 == last1)
         return first2;
@@ -107,7 +107,7 @@ constexpr bit_iterator<ForwardIt2> swap_ranges(
                         last1.position()
                 );
             }
-            return bit_iterator<ForwardIt1>(it2, last1.position());
+            return bit_iterator<RandomAccessIt1>(it2, last1.position());
 
         // first1 range spans mutliple words and is not aligned with first2
         } else {


### PR DESCRIPTION
Given that there are no non-random access/contiguous memory containers, I'm removing the support for input/forward/bidirectional iterators